### PR TITLE
Endpoint to create a short_link

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem 'jbuilder', '~> 2.5'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
+gem 'active_model_serializers'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.12)
+      actionpack (>= 4.1, < 6.2)
+      activemodel (>= 4.1, < 6.2)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (5.2.4.5)
       activesupport (= 5.2.4.5)
       globalid (>= 0.3.6)
@@ -48,6 +53,8 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.3)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -77,6 +84,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    jsonapi-renderer (0.2.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -191,6 +199,7 @@ PLATFORMS
   x86_64-darwin-19
 
 DEPENDENCIES
+  active_model_serializers
   bootsnap (>= 1.1.0)
   byebug
   coffee-rails (~> 4.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,2 @@
-class ApplicationController < ActionController::Base
+class ApplicationController < ActionController::API
 end

--- a/app/controllers/short_links_controller.rb
+++ b/app/controllers/short_links_controller.rb
@@ -6,10 +6,24 @@ class ShortLinksController < ApplicationController
     redirect_to @short_link.full_url
   end
 
+  def create
+    short_link =ShortLink.create(short_link_params)
+    return render_error(short_link) if short_link.invalid?
+    render json: ShortLinkSerializer.new(short_link).to_json, status: :created
+  end
+
   private 
   
   def set_short_link
     @short_link = ShortLink.find_by_slug(params[:id])
     head :not_found unless @short_link
+  end
+
+  def short_link_params 
+    params.permit(:full_url, :user_id)
+  end
+
+  def render_error(resource, status = :unprocessable_entity)
+    render json: { errors: resource.errors.full_messages } , status: status
   end
 end

--- a/app/models/short_link.rb
+++ b/app/models/short_link.rb
@@ -1,6 +1,7 @@
 class ShortLink < ApplicationRecord
   validates :user_id, presence: true
-  validates :full_url, presence: true, uniqueness: { scope: :user_id }
+  validates :full_url, presence: true, uniqueness: { scope: :user_id,
+    message: 'A shortlink already exists for that user and URL' }
   validates :full_url, format: { with: URI::regexp,
     message: 'Please provide a valid url with protocol' }
 

--- a/app/models/short_link.rb
+++ b/app/models/short_link.rb
@@ -1,6 +1,8 @@
 class ShortLink < ApplicationRecord
   validates :user_id, presence: true
   validates :full_url, presence: true, uniqueness: { scope: :user_id }
+  validates :full_url, format: { with: URI::regexp,
+    message: 'Please provide a valid url with protocol' }
 
   def self.find_by_slug(slug)
     id = slug.to_i(36)

--- a/app/serializers/short_link_serializer.rb
+++ b/app/serializers/short_link_serializer.rb
@@ -1,0 +1,3 @@
+class ShortLinkSerializer < ActiveModel::Serializer
+  attributes :short_link, :full_url, :user_id
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get '/:id', to: 'short_links#show'
+  resources :short_links, only: [:create]
 end

--- a/spec/controllers/short_links_controller_spec.rb
+++ b/spec/controllers/short_links_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe ShortLinksController do
   describe 'show' do
-    context 'with a valid shortlink' do
+    context 'with a valid short_link id' do
       let(:short_link) { create(:short_link) }
       let(:request) {get :show, params: {id: short_link.slug}}
       it 'redirects to a long link' do
@@ -11,7 +11,7 @@ describe ShortLinksController do
       end 
     end
 
-    context 'with an invalid shortlink' do
+    context 'when no corresponding short_link exists' do
       let(:request) {get :show, params: {id: -1}}
       it 'returns 404' do
         expect(request.status).to eq(404)

--- a/spec/controllers/short_links_controller_spec.rb
+++ b/spec/controllers/short_links_controller_spec.rb
@@ -22,7 +22,6 @@ describe ShortLinksController do
   describe 'post' do
     let(:short_link) {create(:short_link)}
     let(:valid_url) { 'https://www.fakegoogle.com' }
-
     context 'with a valid request' do
       describe 'when no short_link with the same id and url exists' do
         let(:request) { post :create, params: { user_id: short_link.user_id + 1, full_url: valid_url}

--- a/spec/controllers/short_links_controller_spec.rb
+++ b/spec/controllers/short_links_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 describe ShortLinksController do
-  describe "show" do
-    context "with a valid shortlink" do
-      let(:short_link) {create(:short_link)}
+  describe 'show' do
+    context 'with a valid shortlink' do
+      let(:short_link) { create(:short_link) }
       let(:request) {get :show, params: {id: short_link.slug}}
       it 'redirects to a long link' do
         expect(request.status).to eq(302)
@@ -11,10 +11,62 @@ describe ShortLinksController do
       end 
     end
 
-    context "with an invalid shortlink" do
+    context 'with an invalid shortlink' do
       let(:request) {get :show, params: {id: -1}}
-      it "returns 404" do
+      it 'returns 404' do
         expect(request.status).to eq(404)
+      end
+    end
+  end
+
+  describe 'post' do
+    let(:short_link) {create(:short_link)}
+    let(:valid_url) { 'https://www.fakegoogle.com' }
+
+    context 'with a valid request' do
+      describe 'when no short_link with the same id and url exists' do
+        let(:request) { post :create, params: { user_id: short_link.user_id + 1, full_url: valid_url}
+        }
+        it 'creates a short_link' do
+          expect(request.status).to eq(201)
+        end
+      end
+
+      describe 'when a short_link with the same url but different user_id exists' do
+        let(:request) { post :create, params: { user_id: short_link.user_id, full_url: valid_url }}
+        it 'creates a short_link' do
+          expect(request.status).to eq(201)
+        end
+      end
+    end
+
+    context 'with an invalid request' do
+      describe 'when a short_link with the same url AND user_id exists' do
+        let(:request) { post :create, params: { user_id: short_link.user_id, full_url: short_link.full_url }}
+        it 'does not create a short_link' do
+          expect(request.status).to eq(422)
+        end
+      end
+
+      describe 'when a url is invalid' do
+        let(:request) { post :create, params: { user_id: short_link.user_id, full_url: 'abc123' }}
+        it 'does not create a short_link' do
+          expect(request.status).to eq(422)
+        end
+      end
+
+      describe 'when a url is not provided' do
+        let(:request) { post :create, params: { user_id: short_link.id + 1 }}
+        it 'does not create a short_link' do
+          expect(request.status).to eq(422)
+        end
+      end
+
+      describe 'when a user_id is not provided' do
+        let(:request) { post :create, params: { full_url: valid_url }}
+        it 'does not create a short_link' do
+          expect(request.status).to eq(422)
+        end
       end
     end
   end

--- a/spec/models/short_link_spec.rb
+++ b/spec/models/short_link_spec.rb
@@ -5,9 +5,11 @@ RSpec.describe ShortLink, type: :model do
   describe "validations" do
     it { should validate_presence_of(:user_id) }
     it { should validate_presence_of(:full_url) }
-    it { should validate_uniqueness_of(:full_url).scoped_to(:user_id) }
+    it { should validate_uniqueness_of(:full_url).scoped_to(:user_id).
+      with_message('A shortlink already exists for that user and URL') }
 
     it 'validates format of email' do
+      # shoulda matchers validate_format_of is deprecated
       short_link = build(:short_link, user_id: subject.user_id, full_url: 'no good')
       expect(short_link.invalid?)
       expect(short_link.errors.full_messages).to eq(['Full url Please provide a valid url with protocol'])

--- a/spec/models/short_link_spec.rb
+++ b/spec/models/short_link_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe ShortLink, type: :model do
     it { should validate_presence_of(:user_id) }
     it { should validate_presence_of(:full_url) }
     it { should validate_uniqueness_of(:full_url).scoped_to(:user_id) }
+
+    it 'validates format of email' do
+      short_link = build(:short_link, user_id: subject.user_id, full_url: 'no good')
+      expect(short_link.invalid?)
+      expect(short_link.errors.full_messages).to eq(['Full url Please provide a valid url with protocol'])
+    end
   end
 
   describe 'class methods' do

--- a/spec/serializers/short_link_serializer_spec.rb
+++ b/spec/serializers/short_link_serializer_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe ShortLinkSerializer do
+  subject{ described_class.new(create(:short_link)) }
+
+  describe 'attributes' do
+    it 'serializes a short_link' do
+      expect(subject.attributes.keys).to contain_exactly(:short_link, :full_url, :user_id)
+    end
+  end
+end


### PR DESCRIPTION
- Add a short_link create endpoint with paths for successful creation and unprocessable entity
- Add more short_link model validatitions and custom errors
- Add a Short link serializer and spec
- Make ShortLinkController inherit from APIController to avoid CORS