### PR TITLE
Add analytics endpoint, visit_count to link model

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -1,0 +1,8 @@
+class AnalyticsController < ApplicationController
+
+  before_action :set_short_link, only: [:show]
+
+  def show
+      render json: ShortLinkSerializer.new(@short_link).to_json, status: :ok
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,6 @@
 class ApplicationController < ActionController::API
+  def set_short_link
+    @short_link = ShortLink.find_by_slug(params[:id])
+    head :not_found unless @short_link
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,12 @@
 class ApplicationController < ActionController::API
+
+  private 
   def set_short_link
     @short_link = ShortLink.find_by_slug(params[:id])
     head :not_found unless @short_link
+  end
+
+  def render_error(resource, status = :unprocessable_entity)
+    render json: { errors: resource.errors.full_messages } , status: status
   end
 end

--- a/app/controllers/short_links_controller.rb
+++ b/app/controllers/short_links_controller.rb
@@ -18,8 +18,4 @@ class ShortLinksController < ApplicationController
   def short_link_params 
     params.permit(:full_url, :user_id)
   end
-
-  def render_error(resource, status = :unprocessable_entity)
-    render json: { errors: resource.errors.full_messages } , status: status
-  end
 end

--- a/app/controllers/short_links_controller.rb
+++ b/app/controllers/short_links_controller.rb
@@ -3,21 +3,17 @@ class ShortLinksController < ApplicationController
   before_action :set_short_link, only: [:show]
 
   def show
+    @short_link.visit
     redirect_to @short_link.full_url
   end
 
   def create
-    short_link =ShortLink.create(short_link_params)
+    short_link = ShortLink.create(short_link_params)
     return render_error(short_link) if short_link.invalid?
     render json: ShortLinkSerializer.new(short_link).to_json, status: :created
   end
 
   private 
-  
-  def set_short_link
-    @short_link = ShortLink.find_by_slug(params[:id])
-    head :not_found unless @short_link
-  end
 
   def short_link_params 
     params.permit(:full_url, :user_id)

--- a/app/models/short_link.rb
+++ b/app/models/short_link.rb
@@ -1,5 +1,6 @@
 class ShortLink < ApplicationRecord
   validates :user_id, presence: true
+  validates :visit_count, presence: true
   validates :full_url, presence: true, uniqueness: { scope: :user_id,
     message: 'A shortlink already exists for that user and URL' }
   validates :full_url, format: { with: URI::regexp,
@@ -16,5 +17,9 @@ class ShortLink < ApplicationRecord
 
   def short_link
     ENV["DOMAIN_NAME"] + slug
+  end
+
+  def visit
+    update(visit_count: self.visit_count +=1)
   end
 end

--- a/app/serializers/short_link_serializer.rb
+++ b/app/serializers/short_link_serializer.rb
@@ -1,3 +1,3 @@
 class ShortLinkSerializer < ActiveModel::Serializer
-  attributes :short_link, :full_url, :user_id
+  attributes :short_link, :full_url, :user_id, :visit_count
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get '/:id', to: 'short_links#show'
+  get '/analytics/:id', to: 'analytics#show'
   resources :short_links, only: [:create]
+  
 end

--- a/db/migrate/20210312001412_add_visit_count_to_short_links.rb
+++ b/db/migrate/20210312001412_add_visit_count_to_short_links.rb
@@ -1,0 +1,5 @@
+class AddVisitCountToShortLinks < ActiveRecord::Migration[5.2]
+  def change
+     add_column :short_links, :visit_count, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_10_155553) do
+ActiveRecord::Schema.define(version: 2021_03_12_001412) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2021_03_10_155553) do
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "visit_count", default: 0, null: false
     t.index ["user_id", "full_url"], name: "index_short_links_on_user_id_and_full_url", unique: true
   end
 

--- a/spec/controllers/analytics_controller_spec.rb
+++ b/spec/controllers/analytics_controller_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe AnalyticsController do
+  describe 'show' do
+    context 'when passed a short_links slug' do
+      let(:short_link) { create(:short_link) }
+      let(:request) {get :show, params: {id: short_link.slug}}
+      it 'returns the long_link and times visited' do
+        expect(request.status).to eq(200)
+        expect(JSON.parse(response.body).keys).to contain_exactly(
+          "short_link", "full_url", "user_id", "visit_count"
+        )
+      end
+    end
+
+    context 'when no corresponding short_link exists' do
+      let(:request) {get :show, params: {id: -1}}
+      it 'returns 404' do
+        expect(request.status).to eq(404)
+      end
+    end
+  end
+end

--- a/spec/controllers/short_links_controller_spec.rb
+++ b/spec/controllers/short_links_controller_spec.rb
@@ -9,6 +9,12 @@ describe ShortLinksController do
         expect(request.status).to eq(302)
         expect(request).to redirect_to(short_link.full_url)
       end 
+
+      it 'increments a short_links visit count' do
+        expect(short_link.visit_count).to eq(0)
+        request
+        expect(short_link.reload.visit_count).to eq(1)
+      end
     end
 
     context 'when no corresponding short_link exists' do
@@ -28,6 +34,9 @@ describe ShortLinksController do
         }
         it 'creates a short_link' do
           expect(request.status).to eq(201)
+          expect(JSON.parse(response.body).keys).to contain_exactly(
+          "short_link", "full_url", "user_id", "visit_count"
+        )
         end
       end
 

--- a/spec/models/short_link_spec.rb
+++ b/spec/models/short_link_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe ShortLink, type: :model do
     end
 
     it '.visit increments a short_links visit count' do
-      
       subject.visit
       expect(subject.reload.visit_count).to eq(1)
     end

--- a/spec/models/short_link_spec.rb
+++ b/spec/models/short_link_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ShortLink, type: :model do
   subject { create(:short_link) }
   describe "validations" do
     it { should validate_presence_of(:user_id) }
+    it { should validate_presence_of(:visit_count) }
     it { should validate_presence_of(:full_url) }
     it { should validate_uniqueness_of(:full_url).scoped_to(:user_id).
       with_message('A shortlink already exists for that user and URL') }
@@ -13,6 +14,10 @@ RSpec.describe ShortLink, type: :model do
       short_link = build(:short_link, user_id: subject.user_id, full_url: 'no good')
       expect(short_link.invalid?)
       expect(short_link.errors.full_messages).to eq(['Full url Please provide a valid url with protocol'])
+    end
+
+    it 'defaults visits to 0' do #Set in migration, NOT factory
+      expect(subject.visit_count).to eq(0)
     end
   end
 
@@ -26,8 +31,15 @@ RSpec.describe ShortLink, type: :model do
     it '.slug shows a ShortLinks slug from its id' do
       expect(subject.slug).to eq(subject.id.to_s(36))
     end
+
     it '.short_link concatenates the url_base and slug' do
       expect(subject.short_link).to eq(ENV["DOMAIN_NAME"] + subject.slug)
+    end
+
+    it '.visit increments a short_links visit count' do
+      
+      subject.visit
+      expect(subject.reload.visit_count).to eq(1)
     end
   end
 end

--- a/spec/serializers/short_link_serializer_spec.rb
+++ b/spec/serializers/short_link_serializer_spec.rb
@@ -5,7 +5,7 @@ describe ShortLinkSerializer do
 
   describe 'attributes' do
     it 'serializes a short_link' do
-      expect(subject.attributes.keys).to contain_exactly(:short_link, :full_url, :user_id)
+      expect(subject.attributes.keys).to contain_exactly(:short_link, :full_url, :user_id, :visit_count)
     end
   end
 end


### PR DESCRIPTION
- Add Analytics endpoint that takes a short_link's slug and returns it's visit_count. 
- Refactor ShortLinksController#Show to increment a short_links visit_count
- Move render_error to ApplicationController