### PR TITLE
Add x86_64-linux to Platforms in gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,6 +197,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
   active_model_serializers


### PR DESCRIPTION
While deploying to heroku I received the following error:
```
Bundler Output: Your bundle only supports platforms ["x86_64-darwin-19"] but your local platform
       is x86_64-linux. Add the current platform to the lockfile with `bundle lock
       --add-platform x86_64-linux` and try again.
```

This Gemfile modification is the result of running `bundle lock --add-platform x86_64-linux` 