### PR TITLE
Add 404 link to documentation, add parsed_response helper method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
       PGPASSWORD: ""
       RAILS_ENV: test
       DOMAIN_NAME: "http://localhost:3000/"
+      DOCUMENTATION_url: "https://github.com/Patrick-Duvall/bit1yke"
     # A series of steps to run, some are similar to those in "build".
     steps:
       - checkout 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,10 +3,17 @@ class ApplicationController < ActionController::API
   private 
   def set_short_link
     @short_link = ShortLink.find_by_slug(params[:id])
-    head :not_found unless @short_link
+    render json: not_found, status: :not_found  unless @short_link
   end
 
   def render_error(resource, status = :unprocessable_entity)
     render json: { errors: resource.errors.full_messages } , status: status
+  end
+
+  def not_found
+    {
+      "message": "Not Found",
+      "documentation_url": ENV["DOCUMENTATION_URL"]
+    }.to_json
   end
 end

--- a/spec/controllers/analytics_controller_spec.rb
+++ b/spec/controllers/analytics_controller_spec.rb
@@ -7,7 +7,7 @@ describe AnalyticsController do
       let(:request) {get :show, params: {id: short_link.slug}}
       it 'returns the long_link and times visited' do
         expect(request.status).to eq(200)
-        expect(JSON.parse(response.body).keys).to contain_exactly(
+        expect(parsed_response.keys).to contain_exactly(
           "short_link", "full_url", "user_id", "visit_count"
         )
       end
@@ -17,6 +17,15 @@ describe AnalyticsController do
       let(:request) {get :show, params: {id: -1}}
       it 'returns 404' do
         expect(request.status).to eq(404)
+      end
+      it 'links to the documentation url' do
+        request
+        expect(parsed_response).to eq(
+          {
+            "message" => "Not Found",
+            "documentation_url" => ENV["DOCUMENTATION_URL"]
+          }
+        )
       end
     end
   end

--- a/spec/controllers/short_links_controller_spec.rb
+++ b/spec/controllers/short_links_controller_spec.rb
@@ -22,6 +22,15 @@ describe ShortLinksController do
       it 'returns 404' do
         expect(request.status).to eq(404)
       end
+      it 'links to the documentation url' do
+        request
+        expect(parsed_response).to eq(
+          {
+            "message" => "Not Found",
+            "documentation_url" => ENV["DOCUMENTATION_URL"]
+          }
+        )
+      end
     end
   end
 
@@ -34,7 +43,7 @@ describe ShortLinksController do
         }
         it 'creates a short_link' do
           expect(request.status).to eq(201)
-          expect(JSON.parse(response.body).keys).to contain_exactly(
+          expect(parsed_response.keys).to contain_exactly(
           "short_link", "full_url", "user_id", "visit_count"
         )
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -94,3 +94,7 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 =end
 end
+
+def parsed_response
+  JSON.parse(response.body)
+end


### PR DESCRIPTION
- Add 404 link to readme and spec for analytics and short links controllers
- Add `parsed_response` to spec_helper